### PR TITLE
fix: export `WebpackBundler` separately

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,3 +15,5 @@ import WebpackBundler from './WebpackBundler.js';
 export const plugins = [
   WebpackBundler,
 ];
+
+export { WebpackBundler };


### PR DESCRIPTION
... so you don't have to extend `plugins[0]` in a class deriving from `WebpackBundler`